### PR TITLE
Fix dev container carry-in

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "findrepo2-experiment",
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
     "features": {
         "ghcr.io/devcontainers-contrib/features/poetry:2": {},
         "ghcr.io/guiyomh/features/vim": {},

--- a/.devcontainer/postCreate
+++ b/.devcontainer/postCreate
@@ -15,6 +15,8 @@
 
 set -eu
 
+readonly conf_path='.inherited-configuration'
+
 nl() {
     printf '\n' >&2
 }
@@ -23,14 +25,38 @@ msg() {
     printf '%s: %s\n' "$0" "$1" >&2
 }
 
+pull_in() {
+    local name="$1" value="$2"
+
+    if git config -- "$name" >/dev/null; then
+        msg "not overwriting: $name"
+    else
+        msg "applying: $name"
+        git config --global -- "$name" "$value"
+    fi
+}
+
+pull_all_in() {
+    local name value
+
+    if ! test -e "$conf_path"; then
+        return
+    fi
+
+    while read -r name value; do
+        pull_in "$name" "$value"
+    done <"$conf_path"
+}
+
 nl
 msg 'Customizing global git configuration...'
+pull_all_in
 git config --global color.diff.new blue
 msg '...global git configuration customized.'
 
 nl
 msg 'Customizing fish (the friendly interactive shell)...'
-sudo chsh -s /usr/bin/fish vscode
+sudo chsh -s /usr/bin/fish "$USER"
 fish -c 'set -U __fish_git_prompt_color_cleanstate brgreen'
 fish -c 'set -U __fish_git_prompt_show_informative_status true'
 fish -c 'set -U __fish_git_prompt_showcolorhints true'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 
 # Jupyter notebook checkpoints
 .ipynb_checkpoints/
+
+# Carried-in configuration when building a dev container
+/.inherited-configuration


### PR DESCRIPTION
This corresponds to https://github.com/EliahKagan/palgoviz/pull/58.

I had very closely based the configuration here on the [palgoviz](https://github.com/EliahKagan/palgoviz) configuration, including copying and pasting some parts. As detailed in that PR, I had tried to test all combinations/platforms for palgoviz, but missed the one where the situation we need to carry `user.name` and `user.email` in actually tends to occur. Here, I had not attempted the kind of extensive manual testing that I had (erroneously) thought I had done there, so my mistake there carried over to this repository.

This fixes the bug by adding the missing logic in `postCreate` to apply the configuration, if any, that `initialize` or `initialize.cmd` obtained.