### PR TITLE
Allow poetry to install debugpy dependency

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[installer]
+modern-installation = false


### PR DESCRIPTION
This is https://github.com/python-poetry/poetry/issues/7686.

Same workaround as https://github.com/EliahKagan/palgoviz/pull/88 (https://github.com/python-poetry/poetry/issues/7686#issuecomment-1475402611).