### PR TITLE
Set minimum requests version in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:  # FIXME: Check if html5lib and lxml are really needed.
   - openai
   - pandas
   - pip
-  - requests
+  - requests>=2.31.0
   - tabulate
 
   # Dependencies for tiktoken


### PR DESCRIPTION
I'm not pinning dependencies in environment.yml, and most of them do not give version constraints. For requests, I think it makes sense to constrain the version to be at least 2.30.0, so that a version affected by CVE-2023-32681 is never used accidentally.

See #99 for where the roughly corresponding change was made for poetry dependencies (where it was much more important, because I'm pinning those, so `poetry install` would install a vulnerable version before that).