### PR TITLE
Don't have Dependabot group openai updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     groups:
       python-dependencies:
         patterns: ['*']
+        exclude-patterns: ['openai']
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
So it's easy to take grouped updates without updating the openai package, which will require code changes to bring up to version 1+.