### PR TITLE
Fix outdated instructions an CI workflow

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install poetry
         run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/findrepo2-experiments/install-poetry.py | python3 -
 
+      - name: Install poetry-plugin-export
+        run: poetry self add poetry-plugin-export
+
       - name: Generate requirements.txt
         run: poetry export >requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cd findrepo2-experiment  # When about to use the software.
 conda activate findrepo2-experiment
 ```
 
-Or if using `poetry`:
+Or if using `poetry` (with `poetry-plugin-shell` installed):
 
 ```sh
 cd findrepo2-experiment  # When about to use the software.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 
 These are experiments toward a program like
 [`findrepo`](https://github.com/EliahKagan/newrepo-findrepo#using-findrepo),
-but using
+but using an embedding model like
 [text-embedding-ada-002](https://platform.openai.com/docs/guides/embeddings/embedding-models)
-([OpenAI’s new general purpose text embedding
-model](https://openai.com/blog/new-and-improved-embedding-model/)).
+(which was [OpenAI’s new general purpose text embedding
+model](https://openai.com/blog/new-and-improved-embedding-model/) at the time
+these experiments were begun).
 
 This is in contrast to the custom nonempty-substring frequency vectors
 (non-semantic vocabulary-unaware sparse lossless embeddings in an indefinitely


### PR DESCRIPTION
This adjusts the readme to account for how the model this currently uses is no longer new (which could be explored further in #292), and for how the instructions as written now assume `poetry-plugin-shell`. It also fixes the type-checking workflow by installing `poetry-plugin-export` so that the `poety export` command works and the job can proceed.

The goal here is to fix CI, while also making the minimal readme adjustments to avoid creating a false impression that the readme is current due to the presence of recent non-Dependabot changes. But this does *not* examine every claim in the readme to ensure it is still accurate. In addition, this does not do anything for #293.