### PR TITLE
Always set explicit permissions in CI workflows

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
       - name: flake8 Lint
         uses: py-actions/flake8@v2

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,6 +2,9 @@ name: flake8 Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   flake8-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '15 0,12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -2,6 +2,9 @@ name: pyright Typecheck
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: '3.11'
 
       - name: Upgrade PyPA packages
         run: python -m pip install -U pip setuptools wheel

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,6 +2,9 @@ name: Run ShellCheck
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   shellcheck:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
-      - uses: 'actions/checkout@v4'
-      - uses: 'bewuethr/shellcheck-action@v2'
+      - uses: actions/checkout@v4
+      - uses: bewuethr/shellcheck-action@v2


### PR DESCRIPTION
None but the `codeql.yml` workflow had them. This specifies `contents: read` in the others.

This resolves some CodeQL alerts.