### PR TITLE
Improve Dependabot version update configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: monthly
     allow:
-      - dependency-type: "all"
-    open-pull-requests-limit: 20
+      - dependency-type: all
     groups:
-      python-dependencies:
+      python:
         patterns: ['*']
-        exclude-patterns: ['openai']
+        exclude-patterns:
+          - openai
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: daily
+    groups:
+      actions:
+        patterns: ['*']


### PR DESCRIPTION
Changes:

- Remove unnecessary PR limit for Python version updates, since the use of grouped updates (with only one package outside the group) is sufficient to avoid an excessive number of pull requests.
- Shorten the group name for Python version updates. This is mainly to make PR titles and commit messages more readable.
- Group version updates for GitHub Actions. This is valuable even though the check for those is done daily, because it is possible for multiple actions to receive related updates where it wouldn't be correct to update one and not the other.
- Streamline the YAML code style. This also makes it stylistically consistent with other YAML in the project.